### PR TITLE
package: add a postinstall script when lib is distributed via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "test": "make test",
-    "prepare": "make"
+    "prepare": "make",
+    "postinstall": "make lib/defs.js"
   },
   "keywords": [
     "AMQP",


### PR DESCRIPTION
Right now, the `lib/defs.js` generated file is only available on
packages published on NPM because it is generated during the `prepare`
phase of the NPM packaging step.

By adding a postinstall step we make sure the file is also generated
by other publishing means (be it local package path or git path for
instance).